### PR TITLE
Bump rust to 1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.16.4] - 2025-07-26
+
+- Bump Rust to stable 1.86
+
 ## [0.16.3] - 2025-04-29
 
 - Bump Rust to current stable 1.85.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-alpine AS targetarch
+FROM rust:1.86.0-alpine AS targetarch
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -93,7 +93,7 @@ RUN cd bob_the_builder && \
 #
 # rust-optimizer target
 #
-FROM rust:1.85.1-alpine AS rust-optimizer
+FROM rust:1.86.0-alpine AS rust-optimizer
 
 # Download the crates.io index using the new sparse protocol to improve performance
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DN_OPTIMIZER := "babylonlabs/optimizer"
 DN_RUST_OPTIMIZER := "babylonlabs/rust-optimizer"
 DN_WORKSPACE_OPTIMIZER := "babylonlabs/workspace-optimizer"
-DOCKER_TAG := 0.16.3
+DOCKER_TAG := 0.16.4
 
 # Native arch
 BUILDARCH := $(shell uname -m)


### PR DESCRIPTION
Bump Rust to 1.86.0 since both `rollup-bsn-contracts` and `cosmos-bsn-contracts` are using 1.86.0 now.