### PR TITLE
chore: update reusable_docker_pipeline.yml to v0.13.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.0
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
I noticed that the recent Docker release constantly failed in the last step, I guess it's likely caused by the dep being too old. This PR hopefully fixes it by updating to the latest version, but I'm not 100% sure as it's infeasible to test it on my side. Anyway, it shouldn't be harmful at least.